### PR TITLE
fix(release): align CloudKit transport marker

### DIFF
--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -320,7 +320,7 @@ verify_sync_signature() {
     exit 1
   fi
   if ! /usr/bin/grep -aFq 'iCloud.com.jamesli.tokenremain' "$signed_app/Contents/MacOS/$EXECUTABLE_NAME" \
-    || ! /usr/bin/grep -aFq 'Private sync upload succeeded' "$signed_app/Contents/MacOS/$EXECUTABLE_NAME"; then
+    || ! /usr/bin/grep -aFq 'Private sync source upload succeeded' "$signed_app/Contents/MacOS/$EXECUTABLE_NAME"; then
     echo "Final sync binary was built without the private CloudKit transport." >&2
     exit 1
   fi

--- a/script/verify_installation_isolation.sh
+++ b/script/verify_installation_isolation.sh
@@ -43,7 +43,7 @@ fi
   || fail "staged bundles are not verified before installation"
 /usr/bin/grep -Fq 'verify_bundle_for_mode "$INCOMING_APP"' "$BUILD_SCRIPT" \
   || fail "incoming bundles are not verified before replacement"
-/usr/bin/grep -Fq 'Private sync upload succeeded' "$BUILD_SCRIPT" \
+/usr/bin/grep -Fq 'Private sync source upload succeeded' "$BUILD_SCRIPT" \
   || fail "sync binary marker verification is missing"
 
 echo "installation isolation verified: development and sync builds use protected paths"

--- a/script/verify_release_configuration.sh
+++ b/script/verify_release_configuration.sh
@@ -20,6 +20,9 @@ cd "$ROOT_DIR"
 /bin/bash -n script/package_developer_id_release.sh
 /usr/bin/grep -Fq 'TokenRemain-$VERSION-$BUILD.dmg' script/package_developer_id_release.sh
 /usr/bin/grep -Fq '/usr/bin/cmp -s "$DMG" "$VERSIONED_DMG"' script/package_developer_id_release.sh
+SYNC_SUCCESS_MARKER='Private sync source upload succeeded'
+/usr/bin/grep -Fq "$SYNC_SUCCESS_MARKER" Sources/UsageDock/Sync/CrossDeviceSyncController.swift
+/usr/bin/grep -Fq "$SYNC_SUCCESS_MARKER" script/build_and_run.sh
 /bin/bash -n script/verify_automatic_update_contract.sh
 /bin/bash -n script/verify_installation_isolation.sh
 /bin/bash -n script/verify_bundled_ccusage_contract.sh


### PR DESCRIPTION
## Summary

- align the signed-binary CloudKit transport marker with the v1.2 multi-source upload log
- make release preflight verify that the source and packaging marker remain identical
- update installation-isolation contract coverage

## Validation

- `preflight.sh --release`
- 242 Swift Testing tests across 45 suites
- 14 XCTest tests
- all desktop release contracts

The untracked local `marketing/` directory remains excluded.