### PR TITLE
Fix Claude duplicate weekly rows in v1.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable product changes are recorded here. TokenRemain uses Semantic
 Versioning for public releases.
 
+## Unreleased
+
+### Fixed
+
+- Stop the Claude weekly "all models" row from reappearing as one or two extra
+  model cards when the `/usage` terminal capture drops glyphs from its label,
+  and drop such rows from snapshots cached by an earlier build.
+
 ## 1.2.11 — 2026-08-07
 
 ### Added

--- a/Sources/UsageDock/Models/UsageModels.swift
+++ b/Sources/UsageDock/Models/UsageModels.swift
@@ -51,6 +51,30 @@ struct ScopedQuotaWindow: Sendable, Codable {
     var isAntigravityThirdParty: Bool {
         scopeID.lowercased().hasPrefix("antigravity_3p_")
     }
+
+    /// Claude Code names the general weekly cap `Current week (all models)`.
+    /// It is the same value as the secondary window, never a model-scoped one,
+    /// so a reading carrying that label must not become an extra card.
+    var isGeneralWeeklyLabel: Bool {
+        Self.isGeneralWeeklyLabel(scopeID) || Self.isGeneralWeeklyLabel(displayName)
+    }
+
+    /// Terminal repainting drops glyphs from the label — `all odels`,
+    /// `ll models`, and a copy captured before the trailing `s` painted all
+    /// reach the parser. Accept any spelling that is still `all models` with up
+    /// to two characters missing; no real model name survives that test.
+    static func isGeneralWeeklyLabel(_ name: String) -> Bool {
+        let reference = "allmodels"
+        let normalized = name.lowercased().filter { $0.isASCII && $0.isLetter }
+        guard normalized.count >= reference.count - 2 else { return false }
+        var index = normalized.startIndex
+        for character in reference where index < normalized.endIndex {
+            if normalized[index] == character {
+                index = normalized.index(after: index)
+            }
+        }
+        return index == normalized.endIndex
+    }
 }
 
 /// 订阅限额之外的按量付费消费(Claude 的 extra usage credits)。
@@ -185,10 +209,13 @@ struct ProviderQuota: Sendable, Codable {
     /// Terminal repainting and older cached snapshots can contain the same
     /// model-scoped quota more than once. Keep the latest reading for each
     /// stable scope while preserving the service's original display order.
+    /// Damaged `all models` labels are dropped here rather than only at parse
+    /// time, so a snapshot cached before the parser learned to reject them
+    /// stops rendering phantom cards on the next launch.
     var uniqueScopedWindows: [ScopedQuotaWindow] {
         var order: [String] = []
         var latestByScope: [String: ScopedQuotaWindow] = [:]
-        for scoped in scopedWindows ?? [] {
+        for scoped in scopedWindows ?? [] where !scoped.isGeneralWeeklyLabel {
             let key = scoped.scopeID.lowercased()
             if latestByScope[key] == nil {
                 order.append(key)

--- a/Sources/UsageDock/Services/ClaudeUsageService.swift
+++ b/Sources/UsageDock/Services/ClaudeUsageService.swift
@@ -314,12 +314,11 @@ enum ClaudeCLIUsageParser {
             guard let nameRange = Range(match.range(at: 1), in: text),
                   let bodyRange = Range(match.range(at: 2), in: text) else { return nil }
             let name = text[nameRange].trimmingCharacters(in: .whitespacesAndNewlines)
-            let normalizedName = name.lowercased()
-                .replacingOccurrences(of: #"[^a-z]"#, with: "", options: .regularExpression)
-            // Terminal repainting can drop one leading glyph and turn
-            // `all models` into `all odels`. It is still the general weekly
-            // row, not a model-scoped quota.
-            guard !(normalizedName.contains("all") && normalizedName.contains("odel")) else {
+            // Terminal repainting can drop glyphs anywhere in the label and
+            // turn `all models` into `all odels`, `ll models`, or a copy caught
+            // before the trailing `s` painted. Every one of those is still the
+            // general weekly row, not a model-scoped quota.
+            guard !ScopedQuotaWindow.isGeneralWeeklyLabel(name) else {
                 return nil
             }
             let body = String(text[bodyRange])

--- a/Tests/UsageDockTests/ClaudeCLIUsageParserTests.swift
+++ b/Tests/UsageDockTests/ClaudeCLIUsageParserTests.swift
@@ -167,12 +167,15 @@ struct ClaudeCLIUsageParserTests {
         #expect(scoped[0].window.usedPercent == 14)
     }
 
-    @Test("A repainted all-models label is not treated as a model quota")
-    func ignoresDamagedAllModelsLabel() throws {
+    @Test(
+        "A repainted all-models label is not treated as a model quota",
+        arguments: ["all odels", "ll models", "ll model", "all model", "all  models"]
+    )
+    func ignoresDamagedAllModelsLabel(damagedLabel: String) throws {
         let output = """
         Current session
         8% used
-        Current week (all odels)
+        Current week (\(damagedLabel))
         7% used
         Resets Jul 31 at 1pm
         Current week (Fable)
@@ -183,5 +186,67 @@ struct ClaudeCLIUsageParserTests {
         let quota = try ClaudeCLIUsageParser.parse(Data(output.utf8))
 
         #expect(quota.uniqueScopedWindows.map(\.scopeID) == ["fable"])
+    }
+
+    @Test("Real model labels survive the all-models filter")
+    func keepsRealModelLabels() throws {
+        let output = """
+        Current session
+        8% used
+        Current week (all models)
+        7% used
+        Resets Jul 31 at 1pm
+        Current week (Opus)
+        20% used
+        Resets Aug 1 at 1pm
+        Current week (Fable)
+        14% used
+        Resets Aug 1 at 1pm
+        """
+
+        let quota = try ClaudeCLIUsageParser.parse(Data(output.utf8))
+
+        #expect(quota.uniqueScopedWindows.map(\.scopeID) == ["opus", "fable"])
+    }
+}
+
+@Suite("Scoped quota window sanitation")
+struct ScopedQuotaWindowSanitationTests {
+    private func scoped(_ scopeID: String, _ displayName: String) -> ScopedQuotaWindow {
+        ScopedQuotaWindow(
+            scopeID: scopeID,
+            displayName: displayName,
+            window: QuotaWindow(usedPercent: 5, windowMinutes: 10_080, resetsAt: nil)
+        )
+    }
+
+    @Test("Drops all-models rows cached by an earlier build")
+    func purgesCachedGeneralWeeklyRows() {
+        let quota = ProviderQuota(
+            provider: .claude,
+            primary: QuotaWindow(usedPercent: 47, windowMinutes: 300, resetsAt: nil),
+            secondary: QuotaWindow(usedPercent: 5, windowMinutes: 10_080, resetsAt: nil),
+            planName: nil,
+            capturedAt: .now,
+            scopedWindows: [
+                scoped("ll_model", "ll model"),
+                scoped("ll_models", "ll models"),
+                scoped("fable", "Fable")
+            ]
+        )
+
+        #expect(quota.uniqueScopedWindows.map(\.scopeID) == ["fable"])
+    }
+
+    @Test("Keeps scopes that merely share letters with the label")
+    func keepsUnrelatedScopes() {
+        #expect(!ScopedQuotaWindow.isGeneralWeeklyLabel("Fable"))
+        #expect(!ScopedQuotaWindow.isGeneralWeeklyLabel("Opus"))
+        #expect(!ScopedQuotaWindow.isGeneralWeeklyLabel("Monthly"))
+        #expect(!ScopedQuotaWindow.isGeneralWeeklyLabel("MCP"))
+        #expect(!ScopedQuotaWindow.isGeneralWeeklyLabel("Claude / Third-party"))
+        #expect(!ScopedQuotaWindow.isGeneralWeeklyLabel("modes"))
+        #expect(ScopedQuotaWindow.isGeneralWeeklyLabel("all models"))
+        #expect(ScopedQuotaWindow.isGeneralWeeklyLabel("ll models"))
     }
 }


### PR DESCRIPTION
## Summary
- reject repaint-damaged `all models` weekly rows from Claude Code PTY captures
- sanitize older cached snapshots so phantom weekly cards disappear after updating
- keep the public version and build unchanged at 1.2.11 (25)

## Validation
- release preflight passed
- 16 XCTest tests passed
- 392 Swift Testing tests across 58 suites passed
- release configuration and website contracts passed