### PR TITLE
Windows detection background poll follow-up

### DIFF
--- a/windows/electron/main.js
+++ b/windows/electron/main.js
@@ -48,6 +48,7 @@ const MAX_POPOVER_CONTENT_HEIGHT = 4_000;
 const FLOATING_WIDGET_WIDTH = 80;
 const FLOATING_WIDGET_HEIGHT = 80;
 const REDUCED_MOTION_POLL_MS = 60_000;
+const INSTALLATION_DETECTION_POLL_MS = 5 * 60_000;
 
 let mainWindow;
 let popoverWindow;
@@ -71,6 +72,8 @@ let floatingDragSession;
 let reducedMotion = false;
 let reducedMotionSources = { spi: undefined, electron: undefined };
 let reducedMotionTimer;
+let installationDetectionTimer;
+let installationDetectionPromise;
 let pricingService;
 let serviceStatusService;
 let pendingSecondInstanceLaunchArguments;
@@ -112,6 +115,7 @@ app.whenReady().then(async () => {
   });
   createTray();
   if (initialDetectionSuggestions.length) openDashboard("limits");
+  scheduleInstallationDetection();
   if (initialLaunchArguments.target === "popover") {
     showPopoverWhenReady({ appearanceOpen: initialLaunchArguments.openPopupSettings });
   }
@@ -127,6 +131,7 @@ app.whenReady().then(async () => {
   powerMonitor.on("user-did-become-active", () => {
     scheduleAutomaticRefresh();
     refreshReducedMotionPreference();
+    scanInstalledProviders().catch(() => {}).finally(scheduleInstallationDetection);
   });
   app.on("accessibility-support-changed", refreshReducedMotionPreference);
   if (store.state.preferences?.refreshMinutes !== 0) await refreshAll();
@@ -149,6 +154,7 @@ app.on("before-quit", () => {
   clearTimeout(popoverHideTimer);
   clearTimeout(floatingBoundsSaveTimer);
   clearTimeout(reducedMotionTimer);
+  clearTimeout(installationDetectionTimer);
 });
 
 function createWindow({ showOnReady = false, initialSection } = {}) {
@@ -1243,16 +1249,34 @@ async function checkForAvailableUpdate(fetchImpl, now = Date.now()) {
 }
 
 async function scanInstalledProviders({ announce = true } = {}) {
-  const detections = detectLocalProviders({
-    hasStoredSecret: (providerID) => store.hasProviderSecret(providerID),
-  });
-  store.state.providerDetections = detections;
-  const suggestions = await store.applyProviderDetections(detections);
-  if (announce && suggestions.length) {
-    notifyRenderer();
-    openDashboard("limits");
+  if (installationDetectionPromise) return installationDetectionPromise;
+  installationDetectionPromise = (async () => {
+    const detections = detectLocalProviders({
+      hasStoredSecret: (providerID) => store.hasProviderSecret(providerID),
+    });
+    store.state.providerDetections = detections;
+    const suggestions = await store.applyProviderDetections(detections);
+    if (announce && suggestions.length) {
+      notifyRenderer();
+      openDashboard("limits");
+    }
+    return suggestions;
+  })();
+  try {
+    return await installationDetectionPromise;
+  } finally {
+    installationDetectionPromise = undefined;
   }
-  return suggestions;
+}
+
+function scheduleInstallationDetection() {
+  clearTimeout(installationDetectionTimer);
+  installationDetectionTimer = undefined;
+  if (isQuitting || !store) return;
+  installationDetectionTimer = setTimeout(() => {
+    installationDetectionTimer = undefined;
+    scanInstalledProviders().catch(() => {}).finally(scheduleInstallationDetection);
+  }, INSTALLATION_DETECTION_POLL_MS);
 }
 
 function assertProviderID(providerID) {

--- a/windows/src/main.jsx
+++ b/windows/src/main.jsx
@@ -917,14 +917,13 @@ function Limits({ state, action, onOpenCodexUsage }) {
 
 function DetectionSuggestionPrompt({ suggestion, onConnect, onDismiss }) {
   const name = providerPresentation(suggestion.providerID).name;
-  const message = trKey("provider.detect.prompt_message", [name]).replaceAll("Mac", "PC");
   return (
     <div className="detection-prompt-backdrop">
       <div className="settings-card detection-prompt" role="dialog" aria-modal="true" aria-labelledby="detection-prompt-title">
         <ProviderMark meta={providerPresentation(suggestion.providerID)} size={28} />
         <div>
           <h2 id="detection-prompt-title">{trKey("provider.detect.prompt_title", [name])}</h2>
-          <p>{message}</p>
+          <p>{trKey("provider.detect.prompt_message", [name])}</p>
         </div>
         <div className="detection-prompt-actions">
           <button className="secondary" onClick={onDismiss}>{trKey("provider.detect.not_now")}</button>


### PR DESCRIPTION
Follow-up to #47: the 5-minute background installation-detection poll (mac's monitoring-loop analog) and the prompt message now relying on the PC-worded catalog override rather than a string replacement.

`npm run check`: 265/265 + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)