### PR TITLE
Windows parity local-usage batch: source management + Trends model breakdown

### DIFF
--- a/windows/electron/local-usage.js
+++ b/windows/electron/local-usage.js
@@ -1,8 +1,16 @@
 import { execFile } from "node:child_process";
 import { join } from "node:path";
-import { withLegacyFields } from "../src/usage-history.js";
+import {
+  boundedUsageModels,
+  mergeDailyUsageHistories,
+  withLegacyFields,
+} from "../src/usage-history.js";
 
 export { mergeDailyUsageHistories } from "../src/usage-history.js";
+
+export function aggregateLocalUsageHistories(localHistory, remoteHistory, disabledSourceIDs = []) {
+  return mergeDailyUsageHistories(localHistory, remoteHistory, disabledSourceIDs);
+}
 
 const MAXIMUM_OUTPUT_BYTES = 8 * 1024 * 1024;
 const MAXIMUM_DAYS = 30;
@@ -80,7 +88,24 @@ function normalizeAgent(agent) {
   if (!unpricedModels.length && tokens > 0 && cost === 0 && !modelRows.length && Array.isArray(agent.modelsUsed)) {
     unpricedModels = agent.modelsUsed.filter(validModelName);
   }
-  return [{ id, tokens, cost, unpricedModels: [...new Set(unpricedModels)].sort() }];
+  const models = boundedUsageModels(modelRows.map((row) => ({
+    id: row?.modelName,
+    inputTokens: boundedInteger(row?.inputTokens, MAXIMUM_TOKENS),
+    outputTokens: boundedInteger(row?.outputTokens, MAXIMUM_TOKENS),
+    cacheTokens: Math.min(
+      MAXIMUM_TOKENS,
+      boundedInteger(row?.cacheCreationTokens, MAXIMUM_TOKENS)
+        + boundedInteger(row?.cacheReadTokens, MAXIMUM_TOKENS),
+    ),
+    cost: boundedNumber(row?.cost, MAXIMUM_COST),
+  })));
+  return [{
+    id,
+    tokens,
+    cost,
+    unpricedModels: [...new Set(unpricedModels)].sort(),
+    ...(models.length ? { models } : {}),
+  }];
 }
 
 function normalizeStoredAgent(agent) {
@@ -89,7 +114,8 @@ function normalizeStoredAgent(agent) {
   const cost = boundedNumber(agent?.cost, MAXIMUM_COST);
   if (!id || (tokens === 0 && cost === 0)) return [];
   const unpricedModels = Array.isArray(agent.unpricedModels) ? agent.unpricedModels.filter(validModelName).slice(0, 32) : [];
-  return [{ id, tokens, cost, unpricedModels }];
+  const models = boundedUsageModels(agent?.models);
+  return [{ id, tokens, cost, unpricedModels, ...(models.length ? { models } : {}) }];
 }
 
 function makeDay(day, agents) {

--- a/windows/electron/main.js
+++ b/windows/electron/main.js
@@ -5,7 +5,7 @@ import { fetchCuratedFeed, isAllowedPostURL } from "./feed.js";
 import { isAllowedCodexUsageURL } from "./codex-usage.js";
 import { applyDragDelta } from "./floating-drag.js";
 import { DASHBOARD_SECTIONS, parseLaunchArgs } from "./launch-args.js";
-import { ccusageBinaryPath, collectLocalUsage, mergeDailyUsageHistories } from "./local-usage.js";
+import { aggregateLocalUsageHistories, ccusageBinaryPath, collectLocalUsage, mergeDailyUsageHistories } from "./local-usage.js";
 import { decideProviderNotifications, noticeFromError, selectFeedNotifications, truncateNotificationBody } from "./notification-policy.js";
 import {
   clampPopoverHeight,
@@ -31,6 +31,7 @@ import { exchangeSnapshot, pairWithMac } from "./sync/client.js";
 import { compareVersionCores, fetchLatestRelease, isAllowedReleaseURL, isDue } from "./update-check.js";
 import { mergeLocalFirstProviders, mergeProviders, providerMeta } from "../src/provider-meta.js";
 import { activateLanguage, tr, trKey } from "../src/i18n.js";
+import { detectedLocalUsageSources } from "../src/local-sources.js";
 
 /// A tray double-click arrives as click + double-click. Holding the popover
 /// toggle for this long lets the second click cancel it, so opening the
@@ -648,6 +649,11 @@ function registerIPC() {
     notifyRenderer();
     return publicState();
   });
+  ipcMain.handle("settings:set-local-usage-source-enabled", async (_event, id, enabled) => {
+    await store.setLocalUsageSourceEnabled(id, enabled === true);
+    notifyRenderer();
+    return publicState();
+  });
   ipcMain.handle("settings:set-scoped-pool-visibility", async (_event, key, value) => {
     await store.setScopedPoolVisibility(key, value);
     notifyRenderer();
@@ -1113,7 +1119,13 @@ function publicState() {
   const paired = store?.state?.pairedMac;
   const localDailyUsageHistory = store?.state?.localDailyUsageHistory;
   const remoteDailyUsageHistory = store?.state?.remoteSnapshot?.dailyUsageHistory;
-  const dailyUsageHistory = mergeDailyUsageHistories(localDailyUsageHistory, remoteDailyUsageHistory);
+  const rawDailyUsageHistory = mergeDailyUsageHistories(localDailyUsageHistory, remoteDailyUsageHistory);
+  const disabledLocalUsageSources = store?.state?.preferences?.disabledLocalUsageSources || [];
+  const dailyUsageHistory = aggregateLocalUsageHistories(
+    localDailyUsageHistory,
+    remoteDailyUsageHistory,
+    disabledLocalUsageSources,
+  );
   const pricing = pricingService?.getStatus();
   const providerDetections = store?.state?.providerDetections || [];
   const enabledProviders = normalizeProviderIDs(store?.state?.enabledProviders);
@@ -1139,6 +1151,7 @@ function publicState() {
     // Raw detector values let on-device QA distinguish authoritative SPI from Electron's fallback.
     reducedMotionSources,
     feedNotificationsEnabled: Boolean(store?.state?.preferences?.feedNotificationsEnabled),
+    disabledLocalUsageSources,
     floatingWidgetEnabled: Boolean(store?.state?.preferences?.floatingWidgetEnabled),
     backgroundDepth: store?.state?.preferences?.backgroundDepth ?? 0,
     taskbarIconHidden: Boolean(store?.state?.preferences?.taskbarIconHidden),
@@ -1189,7 +1202,8 @@ function publicState() {
     localUsage: {
       hasLocal: Boolean(localDailyUsageHistory),
       hasRemote: Boolean(remoteDailyUsageHistory),
-      capturedAt: dailyUsageHistory?.capturedAt,
+      capturedAt: rawDailyUsageHistory?.capturedAt,
+      sources: detectedLocalUsageSources(rawDailyUsageHistory),
       source: localDailyUsageHistory && remoteDailyUsageHistory
         ? "This PC + paired Mac"
         : localDailyUsageHistory ? "This PC" : remoteDailyUsageHistory ? "Paired Mac" : undefined,

--- a/windows/electron/preload.cjs
+++ b/windows/electron/preload.cjs
@@ -31,6 +31,7 @@ contextBridge.exposeInMainWorld("tokenRemain", {
   setTaskbarIconHidden: (value) => ipcRenderer.invoke("settings:set-taskbar-icon-hidden", value),
   setZAIRegion: (value) => ipcRenderer.invoke("settings:set-zai-region", value),
   setFeedNotificationsEnabled: (value) => ipcRenderer.invoke("settings:set-feed-notifications", value),
+  setLocalUsageSourceEnabled: (id, enabled) => ipcRenderer.invoke("settings:set-local-usage-source-enabled", id, enabled),
   setScopedPoolVisibility: (key, value) => ipcRenderer.invoke("settings:set-scoped-pool-visibility", key, value),
   setTrayDisplayMode: (value) => ipcRenderer.invoke("settings:set-tray-display-mode", value),
   setTrayProviders: (value) => ipcRenderer.invoke("settings:set-tray-providers", value),

--- a/windows/electron/state-store.js
+++ b/windows/electron/state-store.js
@@ -12,6 +12,12 @@ import {
   normalizeScopedPoolVisibility,
   SCOPED_POOL_CATALOG_KEYS,
 } from "../src/scoped-pools.js";
+import {
+  canonicalLocalSourceID,
+  isWellFormedLocalSourceID,
+  normalizeDisabledLocalUsageSources,
+} from "../src/local-sources.js";
+import { normalizeDailyUsageHistory } from "../src/usage-history.js";
 
 const LANGUAGE_PREFERENCES = new Set(["system", "en", "zh-Hans", "zh-Hant", "ja", "ko", "es", "de"]);
 const TRAY_DISPLAY_MODES = new Set(["full", "compact", "minimal"]);
@@ -70,6 +76,7 @@ export class StateStore {
         Buffer.from(this.state.protectedLocalDailyUsageHistory, "base64"),
       ));
     }
+    this.state.localDailyUsageHistory = normalizeDailyUsageHistory(this.state.localDailyUsageHistory);
     if (this.state.protectedProviderSecrets) {
       if (!this.safeStorage.isEncryptionAvailable()) throw new Error("Windows credential protection is unavailable");
       this.state.providerSecrets = JSON.parse(this.safeStorage.decryptString(
@@ -94,6 +101,7 @@ export class StateStore {
     }
     this.state.preferences = {
       backgroundDepth: DEFAULT_BACKGROUND_DEPTH,
+      disabledLocalUsageSources: [],
       feedNotificationsEnabled: false,
       floatingWidgetEnabled: false,
       language: "system",
@@ -113,6 +121,9 @@ export class StateStore {
     if (!LANGUAGE_PREFERENCES.has(this.state.preferences.language)) this.state.preferences.language = "system";
     if (!isRefreshMinutes(this.state.preferences.refreshMinutes)) this.state.preferences.refreshMinutes = DEFAULT_REFRESH_MINUTES;
     this.state.preferences.feedNotificationsEnabled = this.state.preferences.feedNotificationsEnabled === true;
+    this.state.preferences.disabledLocalUsageSources = normalizeDisabledLocalUsageSources(
+      this.state.preferences.disabledLocalUsageSources,
+    );
     this.state.preferences.backgroundDepth = normalizeBackgroundDepth(this.state.preferences.backgroundDepth);
     this.state.preferences.taskbarIconHidden = this.state.preferences.taskbarIconHidden === true;
     if (!ZAI_REGIONS.has(this.state.preferences.zaiRegion)) this.state.preferences.zaiRegion = "global";
@@ -188,7 +199,7 @@ export class StateStore {
 
   setLocalDailyUsageHistory(history) {
     if (!this.safeStorage.isEncryptionAvailable()) throw new Error("Windows credential protection is unavailable");
-    this.state.localDailyUsageHistory = history;
+    this.state.localDailyUsageHistory = normalizeDailyUsageHistory(history);
   }
 
   getProviderSecret(providerID) {
@@ -306,6 +317,21 @@ export class StateStore {
     this.state.preferences = {
       ...(this.state.preferences || {}),
       feedNotificationsEnabled: enabled === true,
+    };
+    await this.save();
+  }
+
+  async setLocalUsageSourceEnabled(id, enabled) {
+    const canonical = canonicalLocalSourceID(id);
+    if (!isWellFormedLocalSourceID(canonical)) throw new Error("Unsupported local usage source");
+    const disabled = new Set(normalizeDisabledLocalUsageSources(
+      this.state.preferences?.disabledLocalUsageSources,
+    ));
+    if (enabled) disabled.delete(canonical);
+    else disabled.add(canonical);
+    this.state.preferences = {
+      ...(this.state.preferences || {}),
+      disabledLocalUsageSources: [...disabled].sort(),
     };
     await this.save();
   }

--- a/windows/package.json
+++ b/windows/package.json
@@ -11,7 +11,7 @@
     "build": "vite build",
     "start": "npm run build && electron .",
     "test": "node --test tests/*.test.js",
-    "check": "node --check electron/main.js && node --check electron/preload.cjs && node --check electron/background-depth.js && node --check electron/codex-usage.js && node --check electron/launch-args.js && node --check electron/tray-icon.js && node --check electron/feed.js && node --check electron/floating-drag.js && node --check electron/local-usage.js && node --check electron/notification-policy.js && node --check electron/pricing.js && node --check electron/service-status.js && node --check electron/popover-placement.js && node --check electron/refresh-policy.js && node --check electron/system-motion.js && node --check electron/update-check.js && node --check electron/windows-chrome.js && node --check electron/providers/catalog.js && node --check electron/providers/detection.js && node --check electron/providers/index.js && node --check electron/providers/local-session.js && node --check electron/providers/manual.js && node --check electron/providers/shared.js && node --check src/scoped-pools.js && npm test && npm run build",
+    "check": "node --check electron/main.js && node --check electron/preload.cjs && node --check electron/background-depth.js && node --check electron/codex-usage.js && node --check electron/launch-args.js && node --check electron/tray-icon.js && node --check electron/feed.js && node --check electron/floating-drag.js && node --check electron/local-usage.js && node --check electron/notification-policy.js && node --check electron/pricing.js && node --check electron/service-status.js && node --check electron/popover-placement.js && node --check electron/refresh-policy.js && node --check electron/system-motion.js && node --check electron/update-check.js && node --check electron/windows-chrome.js && node --check electron/providers/catalog.js && node --check electron/providers/detection.js && node --check electron/providers/index.js && node --check electron/providers/local-session.js && node --check electron/providers/manual.js && node --check electron/providers/shared.js && node --check src/local-sources.js && node --check src/scoped-pools.js && node --check src/trends-model.js && node --check src/usage-history.js && npm test && npm run build",
     "dist:win": "npm run build && electron-builder --win nsis --publish never",
     "dist:win:x64": "npm run build && electron-builder --x64 --win nsis --publish never"
   },
@@ -43,6 +43,7 @@
       "dist/**/*",
       "electron/**/*",
       "src/i18n.js",
+      "src/local-sources.js",
       "src/locales.generated.js",
       "src/provider-meta.js",
       "src/scoped-pools.js",

--- a/windows/src/local-sources.js
+++ b/windows/src/local-sources.js
@@ -1,0 +1,78 @@
+export const LOCAL_USAGE_SOURCE_CATALOG = Object.freeze([
+  { id: "claude", displayName: "Claude Code" },
+  { id: "codex", displayName: "Codex" },
+  { id: "opencode", displayName: "OpenCode" },
+  { id: "amp", displayName: "Amp" },
+  { id: "droid", displayName: "Droid" },
+  { id: "codebuff", displayName: "Codebuff" },
+  { id: "hermes", displayName: "Hermes Agent" },
+  { id: "pi", displayName: "pi-agent" },
+  { id: "goose", displayName: "Goose" },
+  { id: "openclaw", displayName: "OpenClaw" },
+  { id: "kilo", displayName: "Kilo Code" },
+  { id: "kimi", displayName: "Kimi CLI" },
+  { id: "qwen", displayName: "Qwen CLI" },
+  { id: "copilot", displayName: "GitHub Copilot CLI" },
+  { id: "gemini", displayName: "Gemini" },
+  { id: "trae-agent", displayName: "Trae Agent" },
+].map(Object.freeze));
+
+const SOURCE_BY_ID = new Map(LOCAL_USAGE_SOURCE_CATALOG.map((source) => [source.id, source]));
+const SOURCE_INDEX_BY_ID = new Map(LOCAL_USAGE_SOURCE_CATALOG.map((source, index) => [source.id, index]));
+
+export function canonicalLocalSourceID(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+export function isWellFormedLocalSourceID(value) {
+  return /^[a-z0-9][a-z0-9._-]{0,63}$/.test(canonicalLocalSourceID(value));
+}
+
+export function localSourceDisplayName(value) {
+  const id = canonicalLocalSourceID(value);
+  const known = SOURCE_BY_ID.get(id);
+  if (known) return known.displayName;
+  return id.split(/[-_]/).filter(Boolean).map((part) => (
+    part ? `${part.charAt(0).toUpperCase()}${part.slice(1).toLowerCase()}` : ""
+  )).join(" ");
+}
+
+export function compareLocalSourceIDs(left, right) {
+  const leftID = canonicalLocalSourceID(left);
+  const rightID = canonicalLocalSourceID(right);
+  const leftIndex = SOURCE_INDEX_BY_ID.get(leftID) ?? LOCAL_USAGE_SOURCE_CATALOG.length;
+  const rightIndex = SOURCE_INDEX_BY_ID.get(rightID) ?? LOCAL_USAGE_SOURCE_CATALOG.length;
+  return leftIndex - rightIndex || leftID.localeCompare(rightID);
+}
+
+export function normalizeDisabledLocalUsageSources(value) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.flatMap((item) => {
+    if (typeof item !== "string") return [];
+    const id = canonicalLocalSourceID(item);
+    return isWellFormedLocalSourceID(id) ? [id] : [];
+  }))].sort();
+}
+
+/// Only sources actually present in the bounded recent history become rows.
+/// The catalog is a naming/order authority, not a reason to render undiscovered
+/// agents on a machine that has never used them.
+export function detectedLocalUsageSources(history) {
+  const ids = new Set();
+  for (const day of history?.days || []) {
+    if (Array.isArray(day?.agents)) {
+      for (const agent of day.agents) {
+        const id = canonicalLocalSourceID(agent?.id);
+        if (isWellFormedLocalSourceID(id)) ids.add(id);
+      }
+      continue;
+    }
+    if (Number.isFinite(day?.claudeTokens) && day.claudeTokens > 0) ids.add("claude");
+    if (Number.isFinite(day?.codexTokens) && day.codexTokens > 0) ids.add("codex");
+  }
+  return [...ids].sort(compareLocalSourceIDs).map((id) => ({
+    id,
+    displayName: localSourceDisplayName(id),
+    capturedAt: Number.isFinite(history?.capturedAt) ? history.capturedAt : undefined,
+  }));
+}

--- a/windows/src/main.jsx
+++ b/windows/src/main.jsx
@@ -25,6 +25,7 @@ import {
   ArrowUpRightIcon,
   BoltIcon,
   CheckCircleIcon,
+  CloseIcon,
   ChevronRightIcon,
   DataSourcesIcon,
   DevicesIcon,
@@ -52,12 +53,23 @@ import {
 import { GlassProvider, GlassSurface } from "./glass/GlassSurface.jsx";
 import { LIMITS_ORDER_KEY, normalizeOrder } from "./layout.js";
 import { activateLanguage, languageOptions, SYSTEM_LANGUAGE, tr, trKey } from "./i18n.js";
+import { localSourceDisplayName } from "./local-sources.js";
 import { buildOverviewSummary, buildTodayUsage, rankOfficialQuotaProviders, summaryWindow, usagePace } from "./overview-model.js";
 import { providerMeta } from "./provider-meta.js";
 import { poolDisplayName, providerQuotaDetailRows, visibleScopedWindows } from "./quota-details.js";
 import { scopedPoolSettingsGroups } from "./scoped-pools.js";
-import { compactAxisValue, linePoints, quotaTrendRows, TREND_RANGES, usageTrendModel } from "./trends-model.js";
-import { usageProviderIDs } from "./usage-history.js";
+import {
+  compactAxisValue,
+  linePoints,
+  quotaTrendRows,
+  stepPinnedDay,
+  togglePinnedDay,
+  TREND_RANGES,
+  trendDayModelBreakdown,
+  unpinDay,
+  usageTrendModel,
+} from "./trends-model.js";
+import { filterDailyUsageHistory, usageProviderIDs } from "./usage-history.js";
 import "./styles.css";
 
 const PROVIDER_ICON_MODULES = import.meta.glob("../../site/assets/providers/*.{svg,png}", { eager: true, import: "default" });
@@ -1155,12 +1167,41 @@ function DailyUsageTrendCard({ history }) {
   const [range, setRange] = useState(14);
   const [metric, setMetric] = useState("tokens");
   const [activeIndex, setActiveIndex] = useState();
+  const [pinnedDayID, setPinnedDayID] = useState();
   const providerIDs = usageProviderIDs(history);
   const model = usageTrendModel(history, { range, metric, providerIDs });
   const fresh = history?.capturedAt && Date.now() - history.capturedAt < 30 * 60_000;
   const stride = model.days.length <= 7 ? 1 : model.days.length <= 14 ? 2 : 5;
   const ticks = [1, 0.75, 0.5, 0.25];
   const activeDay = Number.isInteger(activeIndex) ? model.days[activeIndex] : undefined;
+  const pinnedIndex = model.days.findIndex((day) => day.day === pinnedDayID);
+  const pinnedDay = pinnedIndex >= 0 ? history.days.find((day) => day.day === pinnedDayID) : undefined;
+  const breakdown = pinnedDay ? trendDayModelBreakdown(pinnedDay, providerIDs, metric) : undefined;
+
+  useEffect(() => {
+    if (!pinnedDayID) return undefined;
+    const handleEscape = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      setPinnedDayID(unpinDay());
+    };
+    globalThis.addEventListener("keydown", handleEscape);
+    return () => globalThis.removeEventListener("keydown", handleEscape);
+  }, [pinnedDayID]);
+
+  function selectRange(nextRange) {
+    setRange(nextRange);
+    setActiveIndex(undefined);
+    setPinnedDayID(unpinDay());
+  }
+
+  function handleChartKeyDown(event) {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    const next = stepPinnedDay(model.days.map((day) => day.day), pinnedDayID, event.key === "ArrowLeft" ? "left" : "right");
+    setPinnedDayID(next);
+    setActiveIndex(model.days.findIndex((day) => day.day === next));
+  }
 
   return (
     <section className="dashboard-panel trend-history-panel">
@@ -1183,7 +1224,7 @@ function DailyUsageTrendCard({ history }) {
           })}
         </div>
         <div className="trend-control-groups">
-          <TrendSegmentedControl label={tr("History range")} options={TREND_RANGES} value={range} onChange={setRange} />
+          <TrendSegmentedControl label={tr("History range")} options={TREND_RANGES} value={range} onChange={selectRange} />
           <TrendSegmentedControl
             label={tr("Metric")}
             options={[{ value: "tokens", label: tr("Tokens") }, { value: "cost", label: tr("Cost") }]}
@@ -1200,7 +1241,14 @@ function DailyUsageTrendCard({ history }) {
         </svg>
       </div>
 
-      <div className="trend-chart-detailed" onMouseLeave={() => setActiveIndex(undefined)}>
+      <div
+        className="trend-chart-detailed"
+        onMouseLeave={() => setActiveIndex(undefined)}
+        onKeyDown={handleChartKeyDown}
+        role="group"
+        tabIndex={0}
+        aria-label={trKey("trends.chart_accessibility")}
+      >
         <div className="trend-y-axis" aria-hidden="true">
           {ticks.map((fraction) => (
             <span key={fraction} style={{ bottom: `${fraction * 100}%` }}>{compactAxisValue(model.maximum * fraction, metric)}</span>
@@ -1211,17 +1259,19 @@ function DailyUsageTrendCard({ history }) {
           <i className="trend-baseline" />
           <div className={`trend-columns range-${range}`} style={{ gridTemplateColumns: `repeat(${Math.max(1, model.days.length)}, minmax(0, 1fr))` }}>
             {model.days.map((day, index) => {
-              const dimmed = activeDay && index !== activeIndex;
+              const dimmed = pinnedDayID ? day.day !== pinnedDayID : activeDay && index !== activeIndex;
               const labelVisible = (model.days.length - 1 - index) % stride === 0;
               const aria = `${formatDayLabel(day.day)} · ${providerIDs.map((id) => `${providerMeta(id).name} ${trendValue(day.values[id], metric)}`).join(" · ")} · Total ${trendValue(day.total, metric)}`;
               return (
                 <button
-                  className={`trend-day-column ${dimmed ? "dimmed" : ""}`}
+                  className={`trend-day-column ${dimmed ? "dimmed" : ""} ${day.day === pinnedDayID ? "pinned" : ""}`}
                   key={day.day}
                   aria-label={aria}
+                  aria-pressed={day.day === pinnedDayID}
                   onMouseEnter={() => setActiveIndex(index)}
                   onFocus={() => setActiveIndex(index)}
                   onBlur={() => setActiveIndex(undefined)}
+                  onClick={() => setPinnedDayID((current) => togglePinnedDay(current, day.day))}
                 >
                   <span className="trend-stack">
                     {providerIDs.map((id) => day.values[id] > 0 && (
@@ -1243,11 +1293,62 @@ function DailyUsageTrendCard({ history }) {
                 <span key={id}><i style={{ background: providerMeta(id).color }} />{providerMeta(id).name}<b>{trendValue(activeDay.values[id], metric)}</b></span>
               ))}
               <span className="trend-tooltip-total">{tr("Total")}<b>{trendValue(activeDay.total, metric)}</b></span>
+              <span className="trend-tooltip-hint">{trKey("trends.tooltip_click_hint")}</span>
             </div>
           )}
         </div>
       </div>
+      {breakdown && (
+        <TrendModelBreakdownPanel
+          breakdown={breakdown}
+          metric={metric}
+          onClose={() => setPinnedDayID(unpinDay())}
+        />
+      )}
     </section>
+  );
+}
+
+function TrendModelBreakdownPanel({ breakdown, metric, onClose }) {
+  return (
+    <div className="trend-model-panel">
+      <div className="trend-model-heading">
+        <strong>{formatDayLabel(breakdown.day)}</strong>
+        <Badge text={trKey("trends.model_detail_tag")} tone="violet" />
+        <button className="trend-model-close" onClick={onClose} aria-label={trKey("action.close")} title={trKey("action.close")}>
+          <CloseIcon />
+        </button>
+      </div>
+      {breakdown.groups.length ? (
+        <div className="trend-model-groups">
+          {breakdown.groups.map((group) => {
+            const color = providerMeta(group.id).color;
+            return (
+              <div className="trend-model-group" key={group.id}>
+                <div className="trend-model-agent"><i style={{ background: color }} /><strong>{group.displayName}</strong></div>
+                {group.rows.map((row) => {
+                  const displayName = typeof row.displayName === "object"
+                    ? trKey(row.displayName.key, [row.displayName.count])
+                    : row.displayName;
+                  const primary = metric === "tokens"
+                    ? compactNumber(row.totalTokens)
+                    : `${formatMoney(row.cost)}${row.isUnpriced ? "*" : ""}`;
+                  return (
+                    <div className="trend-model-row" key={row.id} title={row.isUnpriced ? trKey("usage.price_unavailable") : row.id}>
+                      <i className="trend-model-accent" style={{ background: color }} />
+                      <strong>{displayName}</strong>
+                      <b>{primary}</b>
+                      <span>{formatPercent(row.share * 100)}</span>
+                      <small>{trKey("trends.model_io_format", [compactNumber(row.inputTokens), compactNumber(row.outputTokens), compactNumber(row.cacheTokens)])}</small>
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      ) : <p className="trend-model-empty">{trKey("trends.model_detail_accumulating")}</p>}
+    </div>
   );
 }
 
@@ -1425,6 +1526,8 @@ function DataSources({ state, action, runtimeError }) {
   const local = new Map((state.localProviders || []).map((provider) => [provider.providerID, provider]));
   const enabled = (state.providerCatalog || []).filter((provider) => provider.enabled);
   const remoteCount = state.sync.paired ? state.providers.filter((provider) => !local.has(provider.providerID)).length : 0;
+  const disabledLocalUsageSources = new Set(state.disabledLocalUsageSources || []);
+  const localUsageSources = state.localUsage?.sources || [];
   const diagnostics = dataSourceDiagnostics(state, runtimeError);
   return (
     <section className="content-section data-sources-section">
@@ -1463,12 +1566,14 @@ function DataSources({ state, action, runtimeError }) {
       </div>
       <div className="settings-card source-list">
         <PanelHeader title={tr("Supporting sources")} subtitle={tr("Usage history, pricing, feed, and optional cross-device fallback.")} />
-        <SourceHealthRow
-          name={tr("Local ccusage")}
-          detail={state.localUsage?.error || tr("Reads supported coding-agent logs on this PC; no separate ccusage install required")}
-          healthy={Boolean(state.localUsage?.hasLocal) && !state.localUsage?.error}
-          capturedAt={state.localUsage?.hasLocal ? state.localUsage.capturedAt : undefined}
-        />
+        {localUsageSources.map((source) => (
+          <LocalUsageSourceRow
+            key={source.id}
+            source={source}
+            enabled={!disabledLocalUsageSources.has(source.id)}
+            action={action}
+          />
+        ))}
         <SourceHealthRow
           name={tr("Public model pricing")}
           detail={state.localUsage?.pricing?.error
@@ -1588,6 +1693,31 @@ function SourceHealthRow({ name, detail, detailTitle, healthy, capturedAt, iconI
         <span className={healthy ? "tone-success" : "tone-warning"}>{tr(status || (healthy ? "Healthy" : "Needs attention"))}</span>
         {capturedAt && <time>{formatClock(capturedAt)}</time>}
         {action && <button className="secondary source-open-app" onClick={action.onSelect}>{action.label}</button>}
+      </div>
+    </div>
+  );
+}
+
+function LocalUsageSourceRow({ source, enabled, action }) {
+  const name = localSourceDisplayName(source.id);
+  return (
+    <div className="source-row local-usage-source-row">
+      <span className={`source-dot ${enabled ? "tone-success" : "tone-muted"}`} aria-hidden="true" />
+      <div>
+        <strong>{name}</strong>
+        <small>{trKey("datasource.local_agent_detail")}</small>
+      </div>
+      <div className="source-status">
+        <button
+          className={`switch ${enabled ? "on" : ""}`}
+          role="switch"
+          aria-checked={enabled}
+          aria-label={trKey("datasource.local_agent_toggle", [name])}
+          onClick={() => action(() => api.setLocalUsageSourceEnabled(source.id, !enabled))}
+        >
+          <span className="knob" />
+        </button>
+        {source.capturedAt && <time>{formatClock(source.capturedAt)}</time>}
       </div>
     </div>
   );
@@ -1932,6 +2062,20 @@ function createPreviewAPI() {
   const previewNow = Date.now();
   const previewParameters = new URLSearchParams(globalThis.location?.search || "");
   const previewDay = new Date(previewNow).toISOString().slice(0, 10);
+  const previewModels = (ids, tokens, cost) => ids.map((id, index) => {
+    const fraction = index === 0 ? 0.56 : index === 1 ? 0.29 : 0.15;
+    const modelTokens = Math.round(tokens * fraction);
+    const inputTokens = Math.round(modelTokens * 0.44);
+    const outputTokens = Math.round(modelTokens * 0.21);
+    return {
+      id,
+      inputTokens,
+      outputTokens,
+      cacheTokens: Math.max(0, modelTokens - inputTokens - outputTokens),
+      cost: Number((cost * fraction).toFixed(2)),
+      constituentCount: 1,
+    };
+  });
   const previewHistoryDays = Array.from({ length: 30 }, (_, index) => {
     const day = new Date(previewNow - (29 - index) * 24 * 60 * 60_000).toISOString().slice(0, 10);
     const pulse = [0.72, 0.7, 1.06, 1.03, 1.62, 1.28, 1.21, 0.18, 0.87, 0.46, 0.84, 1.02, 0.72, 0.55, 0.88][index % 15];
@@ -1944,9 +2088,9 @@ function createPreviewAPI() {
     return {
       day,
       agents: [
-        { id: "codex", tokens: codexTokens, cost: codexCost, unpricedModels: [] },
-        { id: "claude", tokens: claudeTokens, cost: claudeCost, unpricedModels: [] },
-        { id: "gemini", tokens: geminiTokens, cost: geminiCost, unpricedModels: [] },
+        { id: "codex", tokens: codexTokens, cost: codexCost, unpricedModels: [], models: previewModels(["gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.1-codex-mini"], codexTokens, codexCost) },
+        { id: "claude", tokens: claudeTokens, cost: claudeCost, unpricedModels: [], models: previewModels(["claude-opus-4-1", "claude-sonnet-4-5", "claude-haiku-4-5"], claudeTokens, claudeCost) },
+        { id: "gemini", tokens: geminiTokens, cost: geminiCost, unpricedModels: [], models: previewModels(["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"], geminiTokens, geminiCost) },
       ],
       claudeTokens,
       claudeCost,
@@ -1954,6 +2098,7 @@ function createPreviewAPI() {
       codexCost,
     };
   });
+  const previewUsageHistory = { sourceDay: previewDay, capturedAt: previewNow, days: previewHistoryDays };
   const previewLocalProviders = [
     {
       providerID: "claude",
@@ -2025,6 +2170,7 @@ function createPreviewAPI() {
     launchAtLogin: false,
     reducedMotion: false,
     feedNotificationsEnabled: false,
+    disabledLocalUsageSources: [],
     floatingWidgetEnabled: false,
     backgroundDepth: normalizeBackgroundDepth(Number.parseFloat(previewParameters.get("depth"))),
     taskbarIconHidden: false,
@@ -2057,11 +2203,12 @@ function createPreviewAPI() {
       previewCursor,
       previewOpenRouter,
     ],
-    dailyUsageHistory: { sourceDay: previewDay, capturedAt: previewNow, days: previewHistoryDays },
+    dailyUsageHistory: previewUsageHistory,
     localUsage: {
       hasLocal: true,
       hasRemote: true,
       capturedAt: previewNow,
+      sources: ["claude", "codex", "gemini"].map((id) => ({ id, capturedAt: previewNow })),
       source: "This PC + paired Mac",
       pricing: { capturedAt: previewNow - 60_000, modelCount: 2_742, refreshIntervalHours: 6, fallback: "cached-public-table" },
     },
@@ -2115,6 +2262,16 @@ function createPreviewAPI() {
     openUpdate: async () => true,
     setLaunchAtLogin: async (value) => (preview = { ...preview, launchAtLogin: Boolean(value) }),
     setFeedNotificationsEnabled: async (value) => (preview = { ...preview, feedNotificationsEnabled: Boolean(value) }),
+    setLocalUsageSourceEnabled: async (id, enabled) => {
+      const disabled = new Set(preview.disabledLocalUsageSources || []);
+      if (enabled) disabled.delete(id); else disabled.add(id);
+      const disabledLocalUsageSources = [...disabled].sort();
+      return (preview = {
+        ...preview,
+        disabledLocalUsageSources,
+        dailyUsageHistory: filterDailyUsageHistory(previewUsageHistory, disabledLocalUsageSources),
+      });
+    },
     setFloatingWidgetEnabled: async (value) => (preview = { ...preview, floatingWidgetEnabled: Boolean(value) }),
     setBackgroundDepth: async (value) => (preview = { ...preview, backgroundDepth: normalizeBackgroundDepth(value) }),
     setTaskbarIconHidden: async (value) => (preview = { ...preview, taskbarIconHidden: Boolean(value) }),

--- a/windows/src/styles.css
+++ b/windows/src/styles.css
@@ -332,15 +332,17 @@ nav svg { width: 16px; height: 16px; }
 .trend-total-row span { color: var(--muted); font-size: 9px; font-weight: 500; white-space: nowrap; }
 .trend-total-row svg { width: 100%; height: 20px; overflow: visible; }
 .trend-total-row polyline { fill: none; stroke: var(--secondary); stroke-width: .7; stroke-linecap: round; stroke-linejoin: round; stroke-dasharray: .1 3.2; vector-effect: non-scaling-stroke; }
-.trend-chart-detailed { display: grid; grid-template-columns: 58px minmax(0, 1fr); height: 199px; margin-top: 8px; }
+.trend-chart-detailed { display: grid; grid-template-columns: 58px minmax(0, 1fr); height: 199px; margin-top: 8px; border-radius: 5px; outline-offset: 3px; }
 .trend-y-axis { position: relative; height: 175px; }
 .trend-y-axis span { position: absolute; right: 8px; transform: translateY(50%); color: var(--muted); font-family: var(--mono); font-size: 9px; white-space: nowrap; }
 .trend-plot { position: relative; height: 175px; }
 .trend-gridline, .trend-baseline { position: absolute; right: 0; left: 0; height: 1px; background: color-mix(in srgb, var(--border) 55%, transparent); pointer-events: none; }
 .trend-baseline { bottom: 0; background: color-mix(in srgb, var(--secondary) 62%, transparent); }
 .trend-columns { position: absolute; inset: 0 0 -24px; display: grid; height: 199px; align-items: stretch; }
-.trend-day-column { display: grid; min-width: 0; height: 199px; padding: 0; border: 0; outline-offset: -2px; color: inherit; background: transparent; cursor: crosshair; grid-template-rows: 175px 24px; }
+.trend-day-column { position: relative; display: grid; min-width: 0; height: 199px; padding: 0; border: 0; outline-offset: -2px; color: inherit; background: transparent; cursor: pointer; grid-template-rows: 175px 24px; }
 .trend-day-column.dimmed .trend-stack { opacity: .4; }
+.trend-day-column.pinned::after { position: absolute; bottom: 23px; left: 50%; width: 12px; height: 2px; border-radius: 2px; transform: translateX(-50%); background: var(--violet); content: ""; }
+.trend-day-column.pinned .trend-day-label { color: var(--text); }
 .trend-stack { display: flex; height: 175px; flex-direction: column-reverse; justify-content: flex-start; align-items: center; gap: 2px; transition: opacity .12s ease-out; }
 .trend-stack i { display: block; flex: 0 0 auto; width: 10px; min-height: 1px; }
 .range-7 .trend-stack i { width: 12px; }
@@ -354,6 +356,26 @@ nav svg { width: 16px; height: 16px; }
 .trend-tooltip > span i { width: 7px; height: 7px; border-radius: 2px; }
 .trend-tooltip > span b { color: var(--text); font-family: var(--mono); font-size: 9px; font-weight: 500; text-align: right; white-space: nowrap; }
 .trend-tooltip .trend-tooltip-total { grid-template-columns: auto 1fr; margin-top: 1px; padding-top: 5px; border-top: 1px solid var(--border); }
+.trend-tooltip .trend-tooltip-hint { display: block; color: var(--muted); font-size: 9px; line-height: 1.35; text-align: center; }
+.trend-model-panel { display: grid; gap: 10px; margin-top: 12px; padding: 11px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface-2); }
+.trend-model-heading { display: flex; align-items: center; gap: 8px; }
+.trend-model-heading > strong { font-size: 11px; font-weight: 600; }
+.trend-model-heading .badge { color: var(--violet); border-color: color-mix(in srgb, var(--violet) 55%, transparent); }
+.trend-model-close { display: grid; width: 22px; height: 22px; margin-left: auto; padding: 0; place-items: center; border: 0; border-radius: 5px; color: var(--secondary); background: transparent; cursor: pointer; }
+.trend-model-close:hover { color: var(--text); background: var(--surface-3); }
+.trend-model-close svg { width: 11px; height: 11px; }
+.trend-model-groups { display: grid; gap: 12px; max-height: 190px; padding-right: 4px; overflow-y: auto; }
+.trend-model-group { display: grid; gap: 7px; }
+.trend-model-agent { display: flex; align-items: center; gap: 6px; color: var(--secondary); }
+.trend-model-agent i { width: 10px; height: 6px; border-radius: 2px; }
+.trend-model-agent strong { font-size: 11px; font-weight: 600; }
+.trend-model-row { display: grid; grid-template-columns: 3px minmax(0, 1fr) auto 40px; align-items: center; gap: 2px 8px; }
+.trend-model-accent { grid-row: 1 / span 2; width: 3px; height: 16px; border-radius: 99px; opacity: .78; }
+.trend-model-row > strong { overflow: hidden; font-size: 11px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
+.trend-model-row > b { font-family: var(--mono); font-size: 10px; font-weight: 600; white-space: nowrap; }
+.trend-model-row > span { width: 40px; color: var(--muted); font-family: var(--mono); font-size: 9px; text-align: right; }
+.trend-model-row > small { grid-column: 2 / -1; color: var(--muted); font-family: var(--mono); font-size: 9px; }
+.trend-model-empty { min-height: 44px; margin: 0; color: var(--muted); font-size: 11px; line-height: 1.5; }
 
 .quota-trend-panel { display: flex; min-height: 188px; flex-direction: column; }
 .quota-trend-table { display: grid; }
@@ -380,6 +402,7 @@ nav svg { width: 16px; height: 16px; }
 .source-dot { flex: 0 0 8px; width: 8px; height: 8px; margin-top: 5px; border-radius: 50%; }
 .source-dot.tone-success { background: var(--success); }
 .source-dot.tone-warning { background: var(--warning); }
+.source-dot.tone-muted { background: var(--muted); }
 .source-row > div { display: grid; gap: 3px; min-width: 0; flex: 1; }
 .source-row > div strong { font-size: 13px; font-weight: 600; }
 .source-row > div small { color: var(--secondary); font-size: 11px; line-height: 1.5; }

--- a/windows/src/trends-model.js
+++ b/windows/src/trends-model.js
@@ -1,3 +1,6 @@
+import { localSourceDisplayName } from "./local-sources.js";
+import { agentsForUsageDay, boundedUsageModels } from "./usage-history.js";
+
 export const TREND_RANGES = [7, 14, 30];
 export const TREND_METRICS = ["tokens", "cost"];
 
@@ -10,12 +13,17 @@ export function niceCeiling(value) {
   return niceFraction * base;
 }
 
-export function usageTrendModel(history, { range = 14, metric = "tokens", providerIDs = ["claude", "codex"] } = {}) {
+export function usageTrendModel(history, {
+  range = 14,
+  metric = "tokens",
+  providerIDs = ["claude", "codex"],
+  disabledSourceIDs = [],
+} = {}) {
   const safeRange = TREND_RANGES.includes(range) ? range : 14;
   const safeMetric = TREND_METRICS.includes(metric) ? metric : "tokens";
   const source = Array.isArray(history?.days) ? history.days : [];
   const days = source.slice(-safeRange).map((day) => {
-    const agents = new Map(agentsForUsageDay(day).map((agent) => [agent.id, agent]));
+    const agents = new Map(agentsForUsageDay(day, disabledSourceIDs).map((agent) => [agent.id, agent]));
     const values = Object.fromEntries(providerIDs.map((id) => {
       const raw = safeMetric === "tokens" ? agents.get(id)?.tokens : agents.get(id)?.cost;
       return [id, Number.isFinite(raw) && raw > 0 ? raw : 0];
@@ -28,6 +36,84 @@ export function usageTrendModel(history, { range = 14, metric = "tokens", provid
   });
   const maximum = niceCeiling(Math.max(0, ...days.map((day) => day.total)));
   return { days, maximum, metric: safeMetric, range: safeRange, providerIDs };
+}
+
+export function togglePinnedDay(currentDayID, selectedDayID) {
+  return currentDayID === selectedDayID ? undefined : selectedDayID;
+}
+
+export function stepPinnedDay(dayIDs, currentDayID, direction) {
+  const days = Array.isArray(dayIDs) ? dayIDs.filter((day) => typeof day === "string") : [];
+  if (!days.length) return undefined;
+  const currentIndex = days.indexOf(currentDayID);
+  const resolvedIndex = currentIndex >= 0 ? currentIndex : days.length - 1;
+  if (direction === "left" || direction === -1) return days[Math.max(0, resolvedIndex - 1)];
+  if (direction === "right" || direction === 1) return days[Math.min(days.length - 1, resolvedIndex + 1)];
+  return days[resolvedIndex];
+}
+
+export function unpinDay() {
+  return undefined;
+}
+
+/// Projects one retained day into the compact panel shown below the chart.
+/// Retention is capped separately at eight rows; this presentation keeps the
+/// five leading named models and rolls the remaining visible rows into Other.
+export function trendDayModelBreakdown(day, agentIDs, metric = "tokens", namedLimit = 5) {
+  const safeMetric = TREND_METRICS.includes(metric) ? metric : "tokens";
+  const byID = new Map(agentsForUsageDay(day).map((agent) => [agent.id, agent]));
+  const groups = (Array.isArray(agentIDs) ? agentIDs : []).flatMap((requestedID) => {
+    const agentID = String(requestedID || "").toLowerCase();
+    const agent = byID.get(agentID);
+    const models = boundedUsageModels(agent?.models);
+    if (!agent || !models.length) return [];
+    const unpriced = new Set((agent.unpricedModels || []).map((id) => String(id).toLowerCase()));
+    const namedIDs = new Set(models.filter((model) => model.id !== "other").map((model) => model.id.toLowerCase()));
+    const isUnpriced = (model) => unpriced.has(model.id.toLowerCase())
+      || (model.id === "other" && [...unpriced].some((id) => !namedIDs.has(id)));
+    const named = models.filter((model) => model.id !== "other").sort((left, right) => {
+      if (safeMetric === "cost") {
+        const pricingOrder = Number(isUnpriced(left)) - Number(isUnpriced(right));
+        if (pricingOrder) return pricingOrder;
+        if (left.cost !== right.cost) return right.cost - left.cost;
+      } else {
+        const tokenOrder = modelTotalTokens(right) - modelTotalTokens(left);
+        if (tokenOrder) return tokenOrder;
+      }
+      return left.id.localeCompare(right.id);
+    });
+    const limit = Math.max(0, Number.isInteger(namedLimit) ? namedLimit : 5);
+    const kept = named.slice(0, limit);
+    const tail = [...named.slice(limit), ...models.filter((model) => model.id === "other")];
+    const otherIsUnpriced = tail.some(isUnpriced);
+    const displayed = tail.length ? [...kept, combineDisplayedOther(tail)] : kept;
+    const metricTotal = displayed.reduce((total, model) => (
+      total + (safeMetric === "tokens" ? modelTotalTokens(model) : model.cost)
+    ), 0);
+    return [{
+      id: agentID,
+      displayName: localSourceDisplayName(agentID),
+      rows: displayed.map((model) => {
+        const totalTokens = modelTotalTokens(model);
+        const metricValue = safeMetric === "tokens" ? totalTokens : model.cost;
+        return {
+          ...model,
+          displayName: trendModelDisplayName(model),
+          totalTokens,
+          share: metricTotal > 0 ? metricValue / metricTotal : 0,
+          isUnpriced: model.id === "other" ? otherIsUnpriced : isUnpriced(model),
+        };
+      }),
+    }];
+  });
+  return { day: day?.day, groups };
+}
+
+export function trendModelDisplayName(model) {
+  if (model?.id === "other") return { key: "trends.model_other_format", count: model.constituentCount };
+  const raw = String(model?.id || "");
+  const withoutClaude = raw.startsWith("claude-") ? raw.slice("claude-".length) : raw;
+  return withoutClaude.length > 28 ? `${withoutClaude.slice(0, 27)}…` : withoutClaude;
 }
 
 export function compactAxisValue(value, metric = "tokens") {
@@ -78,4 +164,18 @@ export function quotaLinePoints(samples, cutoff, now, width = 100, height = 38) 
     return `${x.toFixed(2)},${y.toFixed(2)}`;
   }).join(" ");
 }
-import { agentsForUsageDay } from "./usage-history.js";
+
+function modelTotalTokens(model) {
+  return model.inputTokens + model.outputTokens + model.cacheTokens;
+}
+
+function combineDisplayedOther(rows) {
+  return rows.reduce((other, row) => ({
+    id: "other",
+    inputTokens: other.inputTokens + row.inputTokens,
+    outputTokens: other.outputTokens + row.outputTokens,
+    cacheTokens: other.cacheTokens + row.cacheTokens,
+    cost: other.cost + row.cost,
+    constituentCount: other.constituentCount + row.constituentCount,
+  }), { id: "other", inputTokens: 0, outputTokens: 0, cacheTokens: 0, cost: 0, constituentCount: 0 });
+}

--- a/windows/src/usage-history.js
+++ b/windows/src/usage-history.js
@@ -1,8 +1,15 @@
-const MAXIMUM_DAYS = 30;
+import { canonicalLocalSourceID, normalizeDisabledLocalUsageSources } from "./local-sources.js";
 
-export function agentsForUsageDay(day) {
+const MAXIMUM_DAYS = 30;
+const MAXIMUM_AGENTS_PER_DAY = 32;
+export const MAXIMUM_MODELS_PER_AGENT = 8;
+const MAXIMUM_MODEL_NAME_LENGTH = 512;
+const MAXIMUM_CONSTITUENT_COUNT = 1_000_000;
+
+export function agentsForUsageDay(day, disabledSourceIDs = []) {
   if (!day) return [];
-  const source = Array.isArray(day.agents) ? day.agents : [
+  const disabled = new Set(normalizeDisabledLocalUsageSources(disabledSourceIDs));
+  const source = Array.isArray(day.agents) ? day.agents.slice(0, MAXIMUM_AGENTS_PER_DAY) : [
     { id: "claude", tokens: day.claudeTokens, cost: day.claudeCost },
     { id: "codex", tokens: day.codexTokens, cost: day.codexCost },
   ];
@@ -10,18 +17,20 @@ export function agentsForUsageDay(day) {
     const id = normalizeAgentID(agent?.id);
     const tokens = numeric(agent?.tokens);
     const cost = numeric(agent?.cost);
-    if (!id || (tokens <= 0 && cost <= 0)) return [];
+    if (!id || disabled.has(id) || (tokens <= 0 && cost <= 0)) return [];
+    const models = boundedUsageModels(agent?.models);
     return [{
       id,
       tokens,
       cost,
-      unpricedModels: Array.isArray(agent.unpricedModels) ? agent.unpricedModels.filter((value) => typeof value === "string") : [],
+      unpricedModels: normalizeUnpricedModels(agent.unpricedModels),
+      ...(models.length ? { models } : {}),
     }];
   });
 }
 
-export function usageDayTotals(day) {
-  const agents = agentsForUsageDay(day);
+export function usageDayTotals(day, disabledSourceIDs = []) {
+  const agents = agentsForUsageDay(day, disabledSourceIDs);
   const tokens = agents.reduce((total, agent) => total + agent.tokens, 0);
   const knownCost = agents.reduce((total, agent) => total + agent.cost, 0);
   const hasUnpricedUsage = agents.some((agent) => agent.unpricedModels.length > 0
@@ -29,10 +38,10 @@ export function usageDayTotals(day) {
   return { agents, tokens, knownCost, cost: hasUnpricedUsage ? undefined : knownCost, hasUnpricedUsage };
 }
 
-export function usageProviderIDs(history, limit = 8) {
+export function usageProviderIDs(history, limit = 8, disabledSourceIDs = []) {
   const totals = new Map();
   for (const day of history?.days || []) {
-    for (const agent of agentsForUsageDay(day)) totals.set(agent.id, (totals.get(agent.id) || 0) + agent.tokens);
+    for (const agent of agentsForUsageDay(day, disabledSourceIDs)) totals.set(agent.id, (totals.get(agent.id) || 0) + agent.tokens);
   }
   return [...totals.entries()]
     .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
@@ -40,9 +49,9 @@ export function usageProviderIDs(history, limit = 8) {
     .map(([id]) => id);
 }
 
-export function mergeDailyUsageHistories(localHistory, remoteHistory) {
-  if (!localHistory) return remoteHistory;
-  if (!remoteHistory) return localHistory;
+export function mergeDailyUsageHistories(localHistory, remoteHistory, disabledSourceIDs = []) {
+  if (!localHistory) return filterDailyUsageHistory(remoteHistory, disabledSourceIDs);
+  if (!remoteHistory) return filterDailyUsageHistory(localHistory, disabledSourceIDs);
   const localDays = new Map((localHistory.days || []).map((day) => [day.day, day]));
   const remoteDays = new Map((remoteHistory.days || []).map((day) => [day.day, day]));
   const dayKeys = [...new Set([...localDays.keys(), ...remoteDays.keys()])].sort().slice(-MAXIMUM_DAYS);
@@ -50,27 +59,100 @@ export function mergeDailyUsageHistories(localHistory, remoteHistory) {
     const merged = new Map();
     for (const day of [localDays.get(dayKey), remoteDays.get(dayKey)]) {
       for (const agent of agentsForUsageDay(day)) {
-        const current = merged.get(agent.id) || { id: agent.id, tokens: 0, cost: 0, unpricedModels: [] };
+        const current = merged.get(agent.id) || { id: agent.id, tokens: 0, cost: 0, unpricedModels: [], models: [] };
         current.tokens += agent.tokens;
         current.cost += agent.cost;
         current.unpricedModels = [...new Set([...current.unpricedModels, ...agent.unpricedModels])].sort();
+        current.models = boundedUsageModels([...(current.models || []), ...(agent.models || [])]);
         merged.set(agent.id, current);
       }
     }
     return withLegacyFields(dayKey, [...merged.values()]);
   });
-  return {
+  return filterDailyUsageHistory({
     sourceDay: localHistory.sourceDay || remoteHistory.sourceDay,
     capturedAt: Math.max(localHistory.capturedAt || 0, remoteHistory.capturedAt || 0),
     days,
+  }, disabledSourceIDs);
+}
+
+export function filterDailyUsageHistory(history, disabledSourceIDs = []) {
+  const normalized = normalizeDailyUsageHistory(history);
+  if (!normalized) return undefined;
+  const disabled = normalizeDisabledLocalUsageSources(disabledSourceIDs);
+  if (!disabled.length) return normalized;
+  return {
+    ...normalized,
+    days: normalized.days.map((day) => withLegacyFields(day.day, agentsForUsageDay(day, disabled))),
   };
 }
 
+export function normalizeDailyUsageHistory(history) {
+  if (!history || typeof history !== "object" || !Array.isArray(history.days)) return undefined;
+  const byDay = new Map();
+  for (const day of history.days) {
+    if (!validDayKey(day?.day)) continue;
+    byDay.set(day.day, withLegacyFields(day.day, agentsForUsageDay(day)));
+  }
+  const normalized = {
+    ...(validDayKey(history.sourceDay) ? { sourceDay: history.sourceDay } : {}),
+    ...(Number.isFinite(history.capturedAt) && history.capturedAt >= 0 ? { capturedAt: history.capturedAt } : {}),
+    days: [...byDay.values()].sort((left, right) => left.day.localeCompare(right.day)).slice(-MAXIMUM_DAYS),
+  };
+  return normalized;
+}
+
+/// Mirrors DailyUsageHistory.boundedModels on macOS: at most eight rows total.
+/// Once the bound is exceeded, seven named rows remain and the tail is summed
+/// into one `other` row, including token categories, cost, and model count.
+export function boundedUsageModels(rows, cap = MAXIMUM_MODELS_PER_AGENT) {
+  if (!Number.isInteger(cap) || cap <= 0 || !Array.isArray(rows)) return [];
+  const merged = new Map();
+  for (const row of rows) {
+    const id = normalizeModelID(row?.id);
+    if (!id || id === "<synthetic>") continue;
+    const previous = merged.get(id);
+    merged.set(id, {
+      id,
+      inputTokens: (previous?.inputTokens || 0) + numeric(row?.inputTokens),
+      outputTokens: (previous?.outputTokens || 0) + numeric(row?.outputTokens),
+      cacheTokens: (previous?.cacheTokens || 0) + numeric(row?.cacheTokens),
+      cost: (previous?.cost || 0) + numeric(row?.cost),
+      constituentCount: Math.max(previous?.constituentCount || 1, boundedConstituentCount(row?.constituentCount)),
+    });
+  }
+  const carriedOther = merged.get("other");
+  merged.delete("other");
+  const ordered = [...merged.values()].sort((left, right) => (
+    modelTotalTokens(right) - modelTotalTokens(left)
+      || right.cost - left.cost
+      || left.id.localeCompare(right.id)
+  ));
+  if (ordered.length + (carriedOther ? 1 : 0) <= cap) {
+    return [...ordered, ...(carriedOther ? [carriedOther] : [])];
+  }
+  const kept = ordered.slice(0, Math.max(0, cap - 1));
+  const other = combineOtherModels([...ordered.slice(Math.max(0, cap - 1)), ...(carriedOther ? [carriedOther] : [])]);
+  return other && (modelTotalTokens(other) > 0 || other.cost > 0) ? [...kept, other] : kept;
+}
+
 export function withLegacyFields(day, agents) {
-  const normalized = agents
-    .filter((agent) => agent?.id && (numeric(agent.tokens) > 0 || numeric(agent.cost) > 0))
-    .map((agent) => ({ ...agent, tokens: numeric(agent.tokens), cost: numeric(agent.cost) }))
-    .sort((left, right) => right.tokens - left.tokens || left.id.localeCompare(right.id));
+  const normalized = agents.flatMap((agent) => {
+    const id = normalizeAgentID(agent?.id);
+    const tokens = numeric(agent?.tokens);
+    const cost = numeric(agent?.cost);
+    if (!id || (tokens <= 0 && cost <= 0)) return [];
+    const models = boundedUsageModels(agent?.models);
+    return [{
+      id,
+      tokens,
+      cost,
+      unpricedModels: normalizeUnpricedModels(agent?.unpricedModels),
+      ...(models.length ? { models } : {}),
+    }];
+  })
+    .sort((left, right) => right.tokens - left.tokens || left.id.localeCompare(right.id))
+    .slice(0, MAXIMUM_AGENTS_PER_DAY);
   const byID = new Map(normalized.map((agent) => [agent.id, agent]));
   return {
     day,
@@ -83,10 +165,50 @@ export function withLegacyFields(day, agents) {
 }
 
 function normalizeAgentID(value) {
-  const result = String(value || "").trim().toLowerCase();
+  const result = canonicalLocalSourceID(value);
   return /^[a-z0-9][a-z0-9._-]{0,63}$/.test(result) ? result : undefined;
 }
 
 function numeric(value) {
   return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function normalizeModelID(value) {
+  if (typeof value !== "string" || value.length > MAXIMUM_MODEL_NAME_LENGTH || /[\u0000-\u001f\u007f]/.test(value)) return undefined;
+  const result = value.trim().toLowerCase();
+  return result || undefined;
+}
+
+function normalizeUnpricedModels(value) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.flatMap((item) => {
+    const id = normalizeModelID(item);
+    return id ? [id] : [];
+  }))].slice(0, 32).sort();
+}
+
+function boundedConstituentCount(value) {
+  return Number.isSafeInteger(value) && value > 0 ? Math.min(value, MAXIMUM_CONSTITUENT_COUNT) : 1;
+}
+
+function modelTotalTokens(model) {
+  return model.inputTokens + model.outputTokens + model.cacheTokens;
+}
+
+function combineOtherModels(rows) {
+  if (!rows.length) return undefined;
+  return rows.reduce((result, row) => ({
+    id: "other",
+    inputTokens: result.inputTokens + row.inputTokens,
+    outputTokens: result.outputTokens + row.outputTokens,
+    cacheTokens: result.cacheTokens + row.cacheTokens,
+    cost: result.cost + row.cost,
+    constituentCount: Math.min(MAXIMUM_CONSTITUENT_COUNT, result.constituentCount + row.constituentCount),
+  }), { id: "other", inputTokens: 0, outputTokens: 0, cacheTokens: 0, cost: 0, constituentCount: 0 });
+}
+
+function validDayKey(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = Date.parse(`${value}T00:00:00.000Z`);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString().slice(0, 10) === value;
 }

--- a/windows/tests/crypto.test.js
+++ b/windows/tests/crypto.test.js
@@ -82,6 +82,24 @@ test("Direct Sync omits Windows-only provider detail fields", () => {
   assert.equal(snapshot.providers[0].codexResetCredits, undefined);
 });
 
+test("Direct Sync keeps retained local model breakdowns off the wire", () => {
+  const snapshot = makeSnapshot({
+    sourceInstanceID,
+    sequence: 3,
+    providers: [],
+    dailyUsageHistory: {
+      sourceDay: "2026-08-25",
+      capturedAt: Date.now(),
+      days: [{
+        day: "2026-08-25",
+        agents: [{ id: "codex", models: [{ id: "gpt-5.3-codex", inputTokens: 10 }] }],
+      }],
+    },
+  });
+  assert.equal(snapshot.dailyUsageHistory, undefined);
+  assert.doesNotMatch(stableStringify(snapshot), /models|gpt-5\.3-codex/);
+});
+
 test("Mac responses bind the paired source and reject replayed sequences", () => {
   const snapshot = makeSnapshot({
     sourceInstanceID: "12345678-1234-4234-8234-123456789abc",

--- a/windows/tests/local-sources.test.js
+++ b/windows/tests/local-sources.test.js
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  detectedLocalUsageSources,
+  LOCAL_USAGE_SOURCE_CATALOG,
+  localSourceDisplayName,
+  normalizeDisabledLocalUsageSources,
+} from "../src/local-sources.js";
+
+test("local usage catalog mirrors the 16 macOS source definitions", () => {
+  assert.deepEqual(LOCAL_USAGE_SOURCE_CATALOG.map(({ id, displayName }) => [id, displayName]), [
+    ["claude", "Claude Code"], ["codex", "Codex"], ["opencode", "OpenCode"], ["amp", "Amp"],
+    ["droid", "Droid"], ["codebuff", "Codebuff"], ["hermes", "Hermes Agent"], ["pi", "pi-agent"],
+    ["goose", "Goose"], ["openclaw", "OpenClaw"], ["kilo", "Kilo Code"], ["kimi", "Kimi CLI"],
+    ["qwen", "Qwen CLI"], ["copilot", "GitHub Copilot CLI"], ["gemini", "Gemini"], ["trae-agent", "Trae Agent"],
+  ]);
+  assert.equal(localSourceDisplayName(" future_agent-cli "), "Future Agent Cli");
+});
+
+test("disabled source preferences accept only canonical well-formed string IDs", () => {
+  assert.deepEqual(normalizeDisabledLocalUsageSources([
+    " Codex ", "codex", "future_agent", 42, "bad source", "", "-invalid",
+  ]), ["codex", "future_agent"]);
+  assert.deepEqual(normalizeDisabledLocalUsageSources("codex"), []);
+});
+
+test("data-source rows include only agents detected in recent raw history", () => {
+  const capturedAt = Date.parse("2026-08-25T10:00:00Z");
+  const sources = detectedLocalUsageSources({ capturedAt, days: [{
+    day: "2026-08-25",
+    agents: [{ id: "gemini", tokens: 20, cost: 0.1 }, { id: "future_agent", tokens: 10, cost: 0 }],
+  }] });
+  assert.deepEqual(sources, [
+    { id: "gemini", displayName: "Gemini", capturedAt },
+    { id: "future_agent", displayName: "Future Agent", capturedAt },
+  ]);
+  assert.ok(!sources.some((source) => source.id === "trae-agent"));
+});

--- a/windows/tests/local-usage.test.js
+++ b/windows/tests/local-usage.test.js
@@ -5,10 +5,14 @@ import {
   ccusageArguments,
   ccusageBinaryPath,
   collectLocalUsage,
+  aggregateLocalUsageHistories,
   mergeDailyUsageHistories,
   parseCCUsageSnapshot,
 } from "../electron/local-usage.js";
 import { usageDayTotals, usageProviderIDs } from "../src/usage-history.js";
+import { buildTodayUsage } from "../src/overview-model.js";
+import { buildUsageDigest } from "../src/popover-model.js";
+import { usageTrendModel } from "../src/trends-model.js";
 
 const NOW = new Date(2026, 7, 10, 12, 0, 0).getTime();
 
@@ -44,9 +48,45 @@ test("Windows ccusage parser keeps every local agent and marks missing prices", 
   assert.equal(history.days[0].claudeTokens, 300);
   assert.equal(history.days[0].codexTokens, 100);
   assert.deepEqual(history.days[0].agents.find((agent) => agent.id === "openclaw").unpricedModels, ["new-model"]);
+  assert.deepEqual(history.days[0].agents.find((agent) => agent.id === "openclaw").models, [{
+    id: "new-model",
+    inputTokens: 25,
+    outputTokens: 25,
+    cacheTokens: 0,
+    cost: 0,
+    constituentCount: 1,
+  }]);
   assert.equal(usageDayTotals(history.days[0]).tokens, 490);
   assert.equal(usageDayTotals(history.days[0]).cost, undefined);
   assert.deepEqual(usageProviderIDs(history), ["claude", "codex", "openclaw", "gemini"]);
+});
+
+test("retained model history is capped at seven named rows plus one other rollup", () => {
+  const models = Array.from({ length: 10 }, (_, index) => ({
+    modelName: `model-${index + 1}`,
+    cost: index + 1,
+    inputTokens: (10 - index) * 100,
+    outputTokens: (10 - index) * 10,
+    cacheCreationTokens: index,
+    cacheReadTokens: index * 2,
+  }));
+  const history = parseCCUsageSnapshot(JSON.stringify({ daily: [{
+    period: "2026-08-10",
+    agents: [{ agent: "codex", totalTokens: 6_160, totalCost: 55, modelBreakdowns: models }],
+  }] }), NOW);
+  const retained = history.days[0].agents[0].models;
+  assert.equal(retained.length, 8);
+  assert.deepEqual(retained.slice(0, 7).map((model) => model.id), [
+    "model-1", "model-2", "model-3", "model-4", "model-5", "model-6", "model-7",
+  ]);
+  assert.deepEqual(retained[7], {
+    id: "other",
+    inputTokens: 600,
+    outputTokens: 60,
+    cacheTokens: 72,
+    cost: 27,
+    constituentCount: 3,
+  });
 });
 
 test("Local ccusage invocation is offline and receives the app-owned price table", async () => {
@@ -98,4 +138,36 @@ test("This PC and paired Mac histories merge without dropping future agent IDs",
   assert.equal(byID.get("gemini").tokens, 40);
   assert.equal(merged.days[0].claudeTokens, 320);
   assert.equal(merged.days[0].codexTokens, 180);
+});
+
+test("disabled sources disappear from today, digests, trends, and the merged Mac-sync aggregate", () => {
+  const local = {
+    sourceDay: "2026-08-10",
+    capturedAt: NOW,
+    days: [{ day: "2026-08-10", agents: [
+      { id: "claude", tokens: 300, cost: 1.5, unpricedModels: [] },
+      { id: "codex", tokens: 100, cost: 0.5, unpricedModels: [] },
+    ] }],
+  };
+  const remote = {
+    sourceDay: "2026-08-10",
+    capturedAt: NOW - 1_000,
+    days: [{ day: "2026-08-10", claudeTokens: 20, claudeCost: 0.2, codexTokens: 80, codexCost: 0.8 }],
+  };
+  const visible = aggregateLocalUsageHistories(local, remote, ["codex"]);
+  assert.deepEqual(visible.days[0].agents.map((agent) => agent.id), ["claude"]);
+  assert.equal(visible.days[0].codexTokens, 0);
+  assert.deepEqual(local.days[0].agents.map((agent) => agent.id), ["claude", "codex"]);
+
+  const today = buildTodayUsage(visible, NOW);
+  assert.equal(today.totalTokens, 320);
+  assert.deepEqual(today.entries.map((entry) => entry.id), ["claude"]);
+
+  const digest = buildUsageDigest(visible, NOW);
+  assert.equal(digest.today.tokens, 320);
+  assert.deepEqual(digest.entries.map((entry) => entry.id), ["claude"]);
+
+  const trend = usageTrendModel(visible, { range: 7, metric: "tokens", providerIDs: usageProviderIDs(visible) });
+  assert.deepEqual(trend.providerIDs, ["claude"]);
+  assert.equal(trend.days[0].total, 320);
 });

--- a/windows/tests/state-store.test.js
+++ b/windows/tests/state-store.test.js
@@ -93,6 +93,68 @@ test("Local ccusage aggregates remain protected at rest", async () => {
     const restored = new StateStore({ userDataPath: directory, safeStorage });
     await restored.load();
     assert.deepEqual(restored.state.localDailyUsageHistory, history);
+    assert.equal(restored.state.localDailyUsageHistory.days[0].agents[0].models, undefined);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Retained per-model usage stays inside the encrypted local history", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "tokenremain-windows-local-model-usage-"));
+  try {
+    const store = new StateStore({ userDataPath: directory, safeStorage });
+    await store.load();
+    store.setLocalDailyUsageHistory({
+      sourceDay: "2026-08-25",
+      capturedAt: 1_787_625_600_000,
+      days: [{ day: "2026-08-25", agents: [{
+        id: "codex",
+        tokens: 100,
+        cost: 0.5,
+        unpricedModels: [],
+        models: [{ id: "gpt-5.3-codex", inputTokens: 40, outputTokens: 20, cacheTokens: 40, cost: 0.5 }],
+      }] }],
+    });
+    await store.save();
+
+    const onDisk = await readFile(join(directory, "state-v1.json"), "utf8");
+    assert.doesNotMatch(onDisk, /gpt-5\.3-codex|inputTokens|localDailyUsageHistory/);
+    const restored = new StateStore({ userDataPath: directory, safeStorage });
+    await restored.load();
+    assert.deepEqual(restored.state.localDailyUsageHistory.days[0].agents[0].models, [{
+      id: "gpt-5.3-codex",
+      inputTokens: 40,
+      outputTokens: 20,
+      cacheTokens: 40,
+      cost: 0.5,
+      constituentCount: 1,
+    }]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("disabled local usage sources default, validate, persist, and restore", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "tokenremain-windows-local-source-preference-"));
+  try {
+    const store = new StateStore({ userDataPath: directory, safeStorage });
+    await store.load();
+    assert.deepEqual(store.state.preferences.disabledLocalUsageSources, []);
+    await store.setLocalUsageSourceEnabled(" Codex ", false);
+    await store.setLocalUsageSourceEnabled("future_agent", false);
+    await store.setLocalUsageSourceEnabled("codex", true);
+    await assert.rejects(() => store.setLocalUsageSourceEnabled("bad source", false), /Unsupported local usage source/);
+
+    const restored = new StateStore({ userDataPath: directory, safeStorage });
+    await restored.load();
+    assert.deepEqual(restored.state.preferences.disabledLocalUsageSources, ["future_agent"]);
+
+    const persisted = JSON.parse(await readFile(join(directory, "state-v1.json"), "utf8"));
+    persisted.preferences.disabledLocalUsageSources = [" Gemini ", "gemini", 42, "bad source", "-invalid"];
+    await writeFile(join(directory, "state-v1.json"), JSON.stringify(persisted));
+    const validated = new StateStore({ userDataPath: directory, safeStorage });
+    await validated.load();
+    assert.deepEqual(validated.state.preferences.disabledLocalUsageSources, ["gemini"]);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/windows/tests/trends-model.test.js
+++ b/windows/tests/trends-model.test.js
@@ -5,6 +5,10 @@ import {
   linePoints,
   niceCeiling,
   quotaTrendRows,
+  stepPinnedDay,
+  togglePinnedDay,
+  trendDayModelBreakdown,
+  unpinDay,
   usageTrendModel,
 } from "../src/trends-model.js";
 
@@ -59,4 +63,53 @@ test("quota rows respect provider order, range, and percentage geometry", () => 
   assert.deepEqual(rows.map((row) => row.providerID), ["claude", "codex"]);
   assert.equal(rows[1].samples.length, 1);
   assert.match(rows[0].points, /,/);
+});
+
+test("day pinning toggles, steps within bounds, and unpins", () => {
+  const days = ["2026-08-23", "2026-08-24", "2026-08-25"];
+  assert.equal(togglePinnedDay(undefined, days[1]), days[1]);
+  assert.equal(togglePinnedDay(days[1], days[1]), undefined);
+  assert.equal(stepPinnedDay(days, undefined, "left"), days[1]);
+  assert.equal(stepPinnedDay(days, days[0], "left"), days[0]);
+  assert.equal(stepPinnedDay(days, days[1], "right"), days[2]);
+  assert.equal(stepPinnedDay(days, days[2], "right"), days[2]);
+  assert.equal(stepPinnedDay([], days[1], "right"), undefined);
+  assert.equal(unpinDay(), undefined);
+});
+
+test("model breakdown keeps five named rows, rolls the tail into Other, and marks missing prices", () => {
+  const models = Array.from({ length: 8 }, (_, index) => ({
+    id: `model-${index + 1}`,
+    inputTokens: (8 - index) * 100,
+    outputTokens: (8 - index) * 10,
+    cacheTokens: index,
+    cost: 8 - index,
+    constituentCount: 1,
+  }));
+  const breakdown = trendDayModelBreakdown({
+    day: "2026-08-25",
+    agents: [{ id: "codex", tokens: 4_000, cost: 36, unpricedModels: ["model-8"], models }],
+  }, ["codex"], "tokens");
+  assert.equal(breakdown.groups.length, 1);
+  assert.equal(breakdown.groups[0].displayName, "Codex");
+  assert.deepEqual(breakdown.groups[0].rows.slice(0, 5).map((row) => row.id), [
+    "model-1", "model-2", "model-3", "model-4", "model-5",
+  ]);
+  const other = breakdown.groups[0].rows[5];
+  assert.equal(other.id, "other");
+  assert.equal(other.constituentCount, 3);
+  assert.equal(other.inputTokens, 600);
+  assert.equal(other.outputTokens, 60);
+  assert.equal(other.cacheTokens, 18);
+  assert.equal(other.cost, 6);
+  assert.equal(other.isUnpriced, true);
+  assert.equal(breakdown.groups[0].rows.reduce((total, row) => total + row.share, 0), 1);
+});
+
+test("old persisted days without models produce the panel's unavailable state", () => {
+  const breakdown = trendDayModelBreakdown({
+    day: "2026-08-25",
+    agents: [{ id: "codex", tokens: 200, cost: 1, unpricedModels: [] }],
+  }, ["codex"], "cost");
+  assert.deepEqual(breakdown, { day: "2026-08-25", groups: [] });
 });


### PR DESCRIPTION
Audit items #4 (minus Trae trajectory parsing, deliberately deferred) + #5:

- 16-agent catalog with per-source disable at the aggregation boundary (raw capture continues; re-enable restores history); per-source Data Sources rows
- Per-model daily retention (mac's 8-row bound + Other rollup; old persisted state degrades gracefully; direct-sync wire stays model-free, test-covered)
- Trends: click-to-pin day, arrow-key stepping, Escape to unpin, per-agent/per-model breakdown panel

`npm run check`: 276/276 + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)