### PR TITLE
fix(menubar): inset Grok's edge-flush brand mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Versioning for public releases.
 
 ## Unreleased
 
+### Fixed
+
+- Grok's menu-bar mark no longer sits flush against the remaining-percent
+  text. The Lobe glyph is a diagonal that fills the PNG canvas; the status
+  item now rasterizes a padded 13pt attachment instead of handing the 640px
+  bitmap to `NSTextAttachmentCell`.
+
 ## 1.3.8 — 2026-08-29
 
 ### Added

--- a/Sources/UsageDock/Support/StatusBarController.swift
+++ b/Sources/UsageDock/Support/StatusBarController.swift
@@ -521,14 +521,13 @@ final class StatusBarController: NSObject {
         _ provider: ProviderQuota.Provider,
         size: CGFloat
     ) -> NSAttributedString {
-        // `BrandIcon.image` already returns a provider-owned NSImage at the
-        // requested size. Avoid force-casting `NSCopying.copy()` here: an
-        // unexpected image subclass implementation would otherwise terminate
-        // the entire menu-bar process while refreshing its title.
-        let image = BrandIcon.image(for: provider, size: size)
+        // Rasterize at the attachment point size. Passing a 640px Lobe PNG
+        // through NSTextAttachmentCell lets AppKit prefer the pixel buffer
+        // over `image.size`, which shifts edge-flush marks such as Grok.
+        let image = BrandIcon.menuBarImage(for: provider, size: size)
 
         let attachment = NSTextAttachment()
-        attachment.attachmentCell = NSTextAttachmentCell(imageCell: image)
+        attachment.image = image
         attachment.bounds = NSRect(x: 0, y: -2, width: size, height: size)
         return NSAttributedString(attachment: attachment)
     }

--- a/Sources/UsageDock/Views/BrandIcon.swift
+++ b/Sources/UsageDock/Views/BrandIcon.swift
@@ -10,6 +10,11 @@ struct BrandIcon: View {
     struct Artwork: Equatable {
         let resourceName: String
         let isTemplate: Bool
+        /// Extra inner padding applied only when rasterizing the menu-bar
+        /// attachment. Zero keeps the vendor canvas. Grok's Lobe mark is a
+        /// diagonal that touches the PNG edges, so it needs room or the 13pt
+        /// status-item glyph sits off the percent baseline.
+        var menuBarPaddingRatio: CGFloat = 0
     }
 
     let provider: ProviderQuota.Provider
@@ -101,6 +106,19 @@ struct BrandIcon: View {
         return image
     }
 
+    /// Rasterizes a status-item glyph whose point size matches the attachment
+    /// bounds. `image(for:size:)` only changes `NSImage.size` on a 640px Lobe
+    /// PNG; `NSTextAttachmentCell` can still key off the pixel buffer and
+    /// draw edge-flush marks (Grok) off the 12pt percent baseline.
+    static func menuBarImage(
+        for provider: ProviderQuota.Provider,
+        size: CGFloat
+    ) -> NSImage {
+        let source = image(for: provider, size: size)
+        let paddingRatio = artwork(for: provider)?.menuBarPaddingRatio ?? 0
+        return rasterizeForMenuBar(source, pointSize: size, paddingRatio: paddingRatio)
+    }
+
     static func artwork(for provider: ProviderQuota.Provider) -> Artwork? {
         switch provider {
         case .claude, .codex:
@@ -108,7 +126,11 @@ struct BrandIcon: View {
         case .cursor:
             return Artwork(resourceName: "cursor", isTemplate: true)
         case .grok:
-            return Artwork(resourceName: "grok", isTemplate: true)
+            return Artwork(
+                resourceName: "grok",
+                isTemplate: true,
+                menuBarPaddingRatio: 0.14
+            )
         case .zai, .zaiTeam:
             return Artwork(resourceName: "zai", isTemplate: true)
         case .copilot:
@@ -191,6 +213,57 @@ struct BrandIcon: View {
                 accessibilityDescription: ProviderQuota.Provider.claude.rawValue
             )
             ?? NSImage(size: NSSize(width: 32, height: 32))
+    }
+
+    /// Draws `source` into a 2× bitmap of `pointSize`. When `paddingRatio` is
+    /// positive, the mark is scaled into a centered inner square so spikes
+    /// that touch the vendor canvas no longer flush against neighboring text.
+    static func rasterizeForMenuBar(
+        _ source: NSImage,
+        pointSize: CGFloat,
+        paddingRatio: CGFloat
+    ) -> NSImage {
+        let scale: CGFloat = 2
+        let pixels = max(1, Int((pointSize * scale).rounded()))
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: pixels,
+            pixelsHigh: pixels,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else {
+            return source
+        }
+        rep.size = NSSize(width: pointSize, height: pointSize)
+
+        // The bitmap context is sized in points (`rep.size`), not pixels.
+        let clampedPad = min(max(paddingRatio, 0), 0.4)
+        let pad = clampedPad * pointSize
+        let inner = max(1, pointSize - 2 * pad)
+        let dest = NSRect(x: pad, y: pad, width: inner, height: inner)
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        NSGraphicsContext.current?.imageInterpolation = .high
+        source.draw(
+            in: dest,
+            from: .zero,
+            operation: .sourceOver,
+            fraction: 1,
+            respectFlipped: false,
+            hints: [.interpolation: NSImageInterpolation.high]
+        )
+        NSGraphicsContext.restoreGraphicsState()
+
+        let image = NSImage(size: NSSize(width: pointSize, height: pointSize))
+        image.addRepresentation(rep)
+        image.isTemplate = source.isTemplate
+        return image
     }
 
     private static func fallbackImage(

--- a/Tests/UsageDockTests/BrandIconRenderTests.swift
+++ b/Tests/UsageDockTests/BrandIconRenderTests.swift
@@ -69,4 +69,64 @@ struct BrandIconRenderTests {
             }
         }
     }
+
+    @Test("Grok menu-bar glyph is inset so the diagonal mark does not flush the canvas")
+    @MainActor
+    func grokMenuBarImageIsPadded() throws {
+        let raw = BrandIcon.image(for: .grok, size: 64)
+        let menu = BrandIcon.menuBarImage(for: .grok, size: 64)
+
+        let rawPad = try #require(minPaddingRatio(of: raw))
+        let menuPad = try #require(minPaddingRatio(of: menu))
+        #expect(rawPad < 0.03, "Grok's Lobe PNG should still touch the canvas (got \(rawPad))")
+        #expect(menuPad > 0.10, "menu-bar Grok glyph should keep inner padding (got \(menuPad))")
+        #expect(menu.size == NSSize(width: 64, height: 64))
+        #expect(menu.isTemplate)
+
+        let bitmap = try #require(NSBitmapImageRep(data: try #require(menu.tiffRepresentation)))
+        #expect(bitmap.pixelsWide == 128)
+        #expect(bitmap.pixelsHigh == 128)
+    }
+
+    @Test("Menu-bar rasterization keeps Claude and Codex filling their canvas")
+    @MainActor
+    func menuBarRasterizationDoesNotShrinkAlreadyPaddedMarks() throws {
+        for provider in [ProviderQuota.Provider.claude, .codex] {
+            let raw = BrandIcon.image(for: provider, size: 64)
+            let menu = BrandIcon.menuBarImage(for: provider, size: 64)
+            let rawPad = try #require(minPaddingRatio(of: raw))
+            let menuPad = try #require(minPaddingRatio(of: menu))
+            #expect(
+                abs(menuPad - rawPad) < 0.06,
+                "\(provider.displayName) padding drifted from \(rawPad) to \(menuPad)"
+            )
+        }
+    }
+
+    private func minPaddingRatio(of image: NSImage) -> CGFloat? {
+        guard let tiff = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff) else {
+            return nil
+        }
+        let width = bitmap.pixelsWide
+        let height = bitmap.pixelsHigh
+        var minX = width
+        var minY = height
+        var maxX = -1
+        var maxY = -1
+        for y in 0..<height {
+            for x in 0..<width {
+                guard let color = bitmap.colorAt(x: x, y: y), color.alphaComponent > 0.08 else {
+                    continue
+                }
+                minX = min(minX, x)
+                minY = min(minY, y)
+                maxX = max(maxX, x)
+                maxY = max(maxY, y)
+            }
+        }
+        guard maxX >= 0 else { return nil }
+        let pad = min(minX, minY, width - 1 - maxX, height - 1 - maxY)
+        return CGFloat(pad) / CGFloat(max(width, height))
+    }
 }


### PR DESCRIPTION
Fixes #53.

## Problem

Grok's Lobe PNG is a diagonal that **touches the 640×640 canvas** (opaque bounds `(0, 13)–(639, 627)`, 0px left/right padding). The menu-bar extra was handing that bitmap to `NSTextAttachmentCell` at 13pt with a global `y = -2` tuned for Claude/Codex. The spikes sat flush against `70%` and read as off the percent baseline.

Dashboard icons are fine — SwiftUI `scaledToFit` in a larger frame hides the missing padding.

## Change

- Rasterize a **2× bitmap whose point size matches the attachment**.
- Give Grok **14% inner padding** (`Artwork.menuBarPaddingRatio`). Claude/Codex stay at 0.
- Use `attachment.image` instead of `NSTextAttachmentCell`.

Verified locally: raw Grok pad ratio `0.0`; menu-bar glyph pad ratio `0.14` on a 128px buffer (`LTRB 18,21,19,20`).

## Tests

Adds `BrandIconRenderTests` coverage that Grok's menu-bar image is inset and Claude/Codex do not shrink. I could not run `swift test` on this machine (CLT Swift 6.3.3 has no `Testing` module; Xcode license not accepted here). The new cases match the existing suite.

## Notes

Does not retouch `grok.png` — the Lobe vendor file stays as-is. Only the status-item rasterizer insets it.